### PR TITLE
Fixed 'implicit conversion changes signedness' warning

### DIFF
--- a/JREnum.h
+++ b/JREnum.h
@@ -79,7 +79,7 @@
     BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
         NSNumber *value = [ENUM_TYPENAME##ByLabel() objectForKey:enumLabel];	\
         if (value) {	\
-            *enumValue = [value intValue];	\
+            *enumValue = (ENUM_TYPENAME)[value intValue];	\
             return YES;	\
         } else {	\
             return NO;	\


### PR DESCRIPTION
The macro `_JREnum_GenerateImplementation` causes a compiler warning - it assigns `[value intValue]` to a variable of enum type. This commit fixes it.
