### PR TITLE
Static functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+JREnumTest/JREnumTest.xcodeproj/project.xcworkspace/xcshareddata/*.xccheckout
+JREnumTest/JREnumTest.xcodeproj/project.xcworkspace/xcuserdata
+JREnumTest/JREnumTest.xcodeproj/xcuserdata
+

--- a/JREnum.h
+++ b/JREnum.h
@@ -46,7 +46,7 @@ static NSArray* _JRPrivate_ParseEnumLabelsAndValuesFromString(NSString *enumStri
         }
         nextDefaultValue = value + 1;
         [labelsAndValues addObject:label];
-        [labelsAndValues addObject:[NSNumber numberWithInt:value]];
+        [labelsAndValues addObject:[NSNumber numberWithInteger:value]];
     }
     return labelsAndValues;
 }

--- a/JREnum.h
+++ b/JREnum.h
@@ -14,27 +14,19 @@
 //--
 
 #define JREnumDeclare(ENUM_TYPENAME, ENUM_CONSTANTS...) \
-    typedef enum {  \
-        ENUM_CONSTANTS  \
-    } ENUM_TYPENAME;    \
-    extern NSDictionary* ENUM_TYPENAME##ByValue();  \
-    extern NSDictionary* ENUM_TYPENAME##ByLabel();  \
-    extern NSString* ENUM_TYPENAME##ToString(int enumValue);    \
-    extern BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue);   \
-    _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wunused-variable\"") \
-    static NSString *_##ENUM_TYPENAME##_constants_string = @"" #ENUM_CONSTANTS; \
-    _Pragma("clang diagnostic pop")
+    _Pragma("GCC warning \"JREnumDeclare is deprecated and should be replaced with JREnum.\"") \
+    JREnum(ENUM_TYPENAME, ENUM_CONSTANTS)
 
 //--
 
+
 #define JREnumDefine(ENUM_TYPENAME) \
-    _JREnum_GenerateImplementation(ENUM_TYPENAME)
+    _Pragma("GCC warning \"JREnumDefine is deprecated and should be removed.\"") \
 
 //--
 
 #define _JREnum_GenerateImplementation(ENUM_TYPENAME)  \
-    NSArray* _JREnumParse##ENUM_TYPENAME##ConstantsString() {	\
+    static NSArray* _JREnumParse##ENUM_TYPENAME##ConstantsString() {	\
         NSString *constantsString = _##ENUM_TYPENAME##_constants_string; \
         constantsString = [[constantsString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""]; \
         if ([constantsString hasSuffix:@","]) { \
@@ -68,7 +60,7 @@
         return labelsAndValues;	\
     }	\
         \
-    NSDictionary* ENUM_TYPENAME##ByValue() {	\
+    static NSDictionary* ENUM_TYPENAME##ByValue() {	\
         NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
         NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
         for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
@@ -79,7 +71,7 @@
         return result;	\
     }	\
         \
-    NSDictionary* ENUM_TYPENAME##ByLabel() {	\
+    static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
         NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
         NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
         for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
@@ -90,7 +82,7 @@
         return result;	\
     }	\
         \
-    NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
+    static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
         NSString *result = [ENUM_TYPENAME##ByValue() objectForKey:[NSNumber numberWithInt:enumValue]];	\
         if (!result) {	\
             result = [NSString stringWithFormat:@"<unknown "#ENUM_TYPENAME": %d>", enumValue];	\
@@ -98,7 +90,7 @@
         return result;	\
     }	\
         \
-    BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
+    static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
         NSNumber *value = [ENUM_TYPENAME##ByLabel() objectForKey:enumLabel];	\
         if (value) {	\
             *enumValue = (ENUM_TYPENAME)[value intValue];	\

--- a/JREnum.h
+++ b/JREnum.h
@@ -5,11 +5,84 @@
 //   https://github.com/rentzsch/JREnum
 
 #define JREnum(ENUM_TYPENAME, ENUM_CONSTANTS...)    \
-    typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
-        ENUM_CONSTANTS  \
-    };    \
-    static NSString *_##ENUM_TYPENAME##_constants_string = @"" #ENUM_CONSTANTS; \
-    _JREnum_GenerateImplementation(ENUM_TYPENAME)
+typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
+    ENUM_CONSTANTS  \
+};    \
+\
+\
+static NSArray* _JREnumParse##ENUM_TYPENAME##ConstantsString() {	\
+    NSString *constantsString = @"" #ENUM_CONSTANTS; \
+    constantsString = [[constantsString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""]; \
+    if ([constantsString hasSuffix:@","]) { \
+        constantsString = [constantsString substringToIndex:[constantsString length]-1]; \
+    } \
+    NSArray *stringPairs = [constantsString componentsSeparatedByString:@","];	\
+    NSMutableArray *labelsAndValues = [NSMutableArray arrayWithCapacity:[stringPairs count]];	\
+    int nextDefaultValue = 0;	\
+    for (NSString *stringPair in stringPairs) {	\
+        NSArray *labelAndValueString = [stringPair componentsSeparatedByString:@"="];	\
+        NSString *label = [labelAndValueString objectAtIndex:0];	\
+        NSString *valueString = [labelAndValueString count] > 1 ? [labelAndValueString objectAtIndex:1] : nil;	\
+        int value; \
+        if (valueString) { \
+            NSRange shiftTokenRange = [valueString rangeOfString:@"<<"]; \
+            if (shiftTokenRange.location != NSNotFound) { \
+                valueString = [valueString substringFromIndex:shiftTokenRange.location + 2]; \
+                value = 1 << [valueString intValue]; \
+            } else if ([valueString hasPrefix:@"0x"]) { \
+                [[NSScanner scannerWithString:valueString] scanHexInt:(unsigned int*)&value]; \
+            } else { \
+                value = [valueString intValue]; \
+            } \
+        } else { \
+            value = nextDefaultValue; \
+        } \
+        nextDefaultValue = value + 1;	\
+        [labelsAndValues addObject:label];	\
+        [labelsAndValues addObject:[NSNumber numberWithInt:value]];	\
+    }	\
+    return labelsAndValues;	\
+}	\
+\
+static NSDictionary* ENUM_TYPENAME##ByValue() {	\
+    NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
+    for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
+        NSString *label = [constants objectAtIndex:i];	\
+        NSNumber *value = [constants objectAtIndex:i+1];	\
+        [result setObject:label forKey:value];	\
+    }	\
+    return result;	\
+}	\
+\
+static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
+    NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
+    for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
+        NSString *label = [constants objectAtIndex:i];	\
+        NSNumber *value = [constants objectAtIndex:i+1];	\
+        [result setObject:value forKey:label];	\
+    }	\
+    return result;	\
+}	\
+\
+static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
+    NSString *result = [ENUM_TYPENAME##ByValue() objectForKey:[NSNumber numberWithInt:enumValue]];	\
+    if (!result) {	\
+        result = [NSString stringWithFormat:@"<unknown "#ENUM_TYPENAME": %d>", enumValue];	\
+    }	\
+    return result;	\
+}	\
+\
+static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
+    NSNumber *value = [ENUM_TYPENAME##ByLabel() objectForKey:enumLabel];	\
+    if (value) {	\
+        *enumValue = (ENUM_TYPENAME)[value intValue];	\
+        return YES;	\
+    } else {	\
+    return NO;	\
+    }	\
+}
 
 //--
 
@@ -24,78 +97,3 @@
     _Pragma("GCC warning \"JREnumDefine is deprecated and should be removed.\"") \
 
 //--
-
-#define _JREnum_GenerateImplementation(ENUM_TYPENAME)  \
-    static NSArray* _JREnumParse##ENUM_TYPENAME##ConstantsString() {	\
-        NSString *constantsString = _##ENUM_TYPENAME##_constants_string; \
-        constantsString = [[constantsString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""]; \
-        if ([constantsString hasSuffix:@","]) { \
-            constantsString = [constantsString substringToIndex:[constantsString length]-1]; \
-        } \
-        NSArray *stringPairs = [constantsString componentsSeparatedByString:@","];	\
-        NSMutableArray *labelsAndValues = [NSMutableArray arrayWithCapacity:[stringPairs count]];	\
-        int nextDefaultValue = 0;	\
-        for (NSString *stringPair in stringPairs) {	\
-            NSArray *labelAndValueString = [stringPair componentsSeparatedByString:@"="];	\
-            NSString *label = [labelAndValueString objectAtIndex:0];	\
-            NSString *valueString = [labelAndValueString count] > 1 ? [labelAndValueString objectAtIndex:1] : nil;	\
-            int value; \
-            if (valueString) { \
-                NSRange shiftTokenRange = [valueString rangeOfString:@"<<"]; \
-                if (shiftTokenRange.location != NSNotFound) { \
-                    valueString = [valueString substringFromIndex:shiftTokenRange.location + 2]; \
-                    value = 1 << [valueString intValue]; \
-                } else if ([valueString hasPrefix:@"0x"]) { \
-                    [[NSScanner scannerWithString:valueString] scanHexInt:(unsigned int*)&value]; \
-                } else { \
-                    value = [valueString intValue]; \
-                } \
-            } else { \
-                value = nextDefaultValue; \
-            } \
-            nextDefaultValue = value + 1;	\
-            [labelsAndValues addObject:label];	\
-            [labelsAndValues addObject:[NSNumber numberWithInt:value]];	\
-        }	\
-        return labelsAndValues;	\
-    }	\
-        \
-    static NSDictionary* ENUM_TYPENAME##ByValue() {	\
-        NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
-        NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
-        for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
-            NSString *label = [constants objectAtIndex:i];	\
-            NSNumber *value = [constants objectAtIndex:i+1];	\
-            [result setObject:label forKey:value];	\
-        }	\
-        return result;	\
-    }	\
-        \
-    static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
-        NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
-        NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
-        for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
-            NSString *label = [constants objectAtIndex:i];	\
-            NSNumber *value = [constants objectAtIndex:i+1];	\
-            [result setObject:value forKey:label];	\
-        }	\
-        return result;	\
-    }	\
-        \
-    static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
-        NSString *result = [ENUM_TYPENAME##ByValue() objectForKey:[NSNumber numberWithInt:enumValue]];	\
-        if (!result) {	\
-            result = [NSString stringWithFormat:@"<unknown "#ENUM_TYPENAME": %d>", enumValue];	\
-        }	\
-        return result;	\
-    }	\
-        \
-    static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
-        NSNumber *value = [ENUM_TYPENAME##ByLabel() objectForKey:enumLabel];	\
-        if (value) {	\
-            *enumValue = (ENUM_TYPENAME)[value intValue];	\
-            return YES;	\
-        } else {	\
-            return NO;	\
-        }	\
-    }

--- a/JREnum.h
+++ b/JREnum.h
@@ -25,12 +25,12 @@ static NSArray* _JRPrivate_ParseEnumLabelsAndValuesFromString(NSString *enumStri
     }
     NSArray *stringPairs = [normalized componentsSeparatedByString:@","];
     NSMutableArray *labelsAndValues = [NSMutableArray arrayWithCapacity:[stringPairs count]];
-    int nextDefaultValue = 0;
+    NSInteger nextDefaultValue = 0;
     for (NSString *stringPair in stringPairs) {
         NSArray *labelAndValueString = [stringPair componentsSeparatedByString:@"="];
         NSString *label = [labelAndValueString objectAtIndex:0];
         NSString *valueString = [labelAndValueString count] > 1 ? [labelAndValueString objectAtIndex:1] : nil;
-        int value;
+        NSInteger value;
         if (valueString) {
             NSRange shiftTokenRange = [valueString rangeOfString:@"<<"];
             if (shiftTokenRange.location != NSNotFound) {
@@ -94,7 +94,7 @@ static NSDictionary* _JRPrivate_EnumByLabel(NSArray *labelsAndValues) {
 
  @return The label for enumValue.
  */
-static NSString* _JRPrivate_EnumToString(NSArray *labelsAndValues, NSString *enumTypeName, int enumValue) {
+static NSString* _JRPrivate_EnumToString(NSArray *labelsAndValues, NSString *enumTypeName, NSInteger enumValue) {
     NSString *result = [_JRPrivate_EnumByValue(labelsAndValues) objectForKey:[NSNumber numberWithInt:enumValue]];
     if (!result) {
         result = [NSString stringWithFormat:@"<unknown %@: %d>", enumTypeName, enumValue];
@@ -148,7 +148,7 @@ static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
     return _JRPrivate_EnumByLabel(labelsAndValues); \
 }	\
 \
-static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
+static NSString* ENUM_TYPENAME##ToString(NSInteger enumValue) {	\
     NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
     NSString *enumTypeName = @"" #ENUM_TYPENAME; \
     return _JRPrivate_EnumToString(labelsAndValues, enumTypeName, enumValue); \

--- a/JREnum.h
+++ b/JREnum.h
@@ -4,6 +4,8 @@
 //   Some rights reserved: http://opensource.org/licenses/mit
 //   https://github.com/rentzsch/JREnum
 
+#pragma mark - Private functions (called by functions defined in macros)
+
 static NSArray* _JRPrivate_ParseEnumLabelsAndValuesFromString(NSString *rawString) {
     NSString *enumString = [[rawString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""];
     if ([enumString hasSuffix:@","]) {
@@ -77,6 +79,9 @@ static BOOL _JRPrivate_EnumFromString(NSArray *labelsAndValues, NSString *enumLa
 
 
 
+#pragma mark - JREnum macro
+//--
+
 #define JREnum(ENUM_TYPENAME, ENUM_CONSTANTS...)    \
 typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
     ENUM_CONSTANTS  \
@@ -109,6 +114,9 @@ static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumVa
     return _JRPrivate_EnumFromString(labelsAndValues, enumLabel, enumValue); \
 }
 
+
+
+#pragma mark - Deprecated macros
 //--
 
 #define JREnumDeclare(ENUM_TYPENAME, ENUM_CONSTANTS...) \
@@ -116,7 +124,6 @@ static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumVa
     JREnum(ENUM_TYPENAME, ENUM_CONSTANTS)
 
 //--
-
 
 #define JREnumDefine(ENUM_TYPENAME) \
     _Pragma("GCC warning \"JREnumDefine is deprecated and should be removed.\"") \

--- a/JREnum.h
+++ b/JREnum.h
@@ -9,7 +9,7 @@
  Parses enumString into an array of interleaved labels and keys.
  
  TODO: Document restrictions on key. The follow, for example, will have strange results:
-     1. JREnumValue = NSNotFound
+     1. JREnumValue = NSNotFound (NSNotFound is defined as a enum value. If it were `#define`d then it would work as we'd receive the post-processed value.)
      2. JREnumNewValue = 0, JRValueOldEnum = JREnumNewValue,
      3. ArfVoid = 0, Arf1, Arf2 = (Arf1 * (2 + ArfVoid)),
  It's possible to improve the function so that it can parse cases 2 and 3 but not case 1.
@@ -135,7 +135,7 @@ typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
 \
 \
 static NSArray* _##ENUM_TYPENAME##LabelsAndValues() {	\
-    NSString *enumString = @"" #ENUM_CONSTANTS; \
+    static NSString *enumString = @"" #ENUM_CONSTANTS; \
     return _JRPrivate_ParseEnumLabelsAndValuesFromString(enumString); \
 } \
 \

--- a/JREnum.h
+++ b/JREnum.h
@@ -111,6 +111,7 @@ static NSString* _JRPrivate_EnumToString(NSArray *labelsAndValues, NSString *enu
 
  @return YES on success otherwise NO.
  */
+static BOOL _JRPrivate_EnumFromString(NSArray *labelsAndValues, NSString *enumLabel, NSInteger *enumValue) __attribute__((nonnull(3)));
 static BOOL _JRPrivate_EnumFromString(NSArray *labelsAndValues, NSString *enumLabel, NSInteger *enumValue) {
     NSNumber *value = [_JRPrivate_EnumByLabel(labelsAndValues) objectForKey:enumLabel];
     if (value) {
@@ -153,6 +154,7 @@ static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
     return _JRPrivate_EnumToString(labelsAndValues, enumTypeName, enumValue); \
 }	\
 \
+static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) __attribute__((nonnull(2))); \
 static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
     NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
     return _JRPrivate_EnumFromString(labelsAndValues, enumLabel, enumValue); \

--- a/JREnum.h
+++ b/JREnum.h
@@ -4,7 +4,7 @@
 //   Some rights reserved: http://opensource.org/licenses/mit
 //   https://github.com/rentzsch/JREnum
 
-static NSArray* _JRPrivate_ParseEnumFromString(NSString *rawString) {
+static NSArray* _JRPrivate_ParseEnumLabelsAndValuesFromString(NSString *rawString) {
     NSString *enumString = [[rawString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""];
     if ([enumString hasSuffix:@","]) {
         enumString = [enumString substringToIndex:[enumString length]-1];
@@ -37,36 +37,36 @@ static NSArray* _JRPrivate_ParseEnumFromString(NSString *rawString) {
     return labelsAndValues;
 }
 
-static NSDictionary* _JRPrivate_EnumByValue(NSArray *constants) {
-    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];
-    for (NSUInteger i = 0; i < [constants count]; i += 2) {
-        NSString *label = [constants objectAtIndex:i];
-        NSNumber *value = [constants objectAtIndex:i+1];
+static NSDictionary* _JRPrivate_EnumByValue(NSArray *labelsAndValues) {
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[labelsAndValues count] / 2];
+    for (NSUInteger i = 0; i < [labelsAndValues count]; i += 2) {
+        NSString *label = [labelsAndValues objectAtIndex:i];
+        NSNumber *value = [labelsAndValues objectAtIndex:i+1];
         [result setObject:label forKey:value];
     }
     return result;
 }
 
-static NSDictionary* _JRPrivate_EnumByLabel(NSArray *constants) {
-    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];
-    for (NSUInteger i = 0; i < [constants count]; i += 2) {
-        NSString *label = [constants objectAtIndex:i];
-        NSNumber *value = [constants objectAtIndex:i+1];
+static NSDictionary* _JRPrivate_EnumByLabel(NSArray *labelsAndValues) {
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[labelsAndValues count] / 2];
+    for (NSUInteger i = 0; i < [labelsAndValues count]; i += 2) {
+        NSString *label = [labelsAndValues objectAtIndex:i];
+        NSNumber *value = [labelsAndValues objectAtIndex:i+1];
         [result setObject:value forKey:label];
     }
     return result;
 }
 
-static NSString* _JRPrivate_EnumToString(NSArray *constants, NSString *enumTypeName, int enumValue) {
-    NSString *result = [_JRPrivate_EnumByValue(constants) objectForKey:[NSNumber numberWithInt:enumValue]];
+static NSString* _JRPrivate_EnumToString(NSArray *labelsAndValues, NSString *enumTypeName, int enumValue) {
+    NSString *result = [_JRPrivate_EnumByValue(labelsAndValues) objectForKey:[NSNumber numberWithInt:enumValue]];
     if (!result) {
         result = [NSString stringWithFormat:@"<unknown %@: %d>", enumTypeName, enumValue];
     }
     return result;
 }
 
-static BOOL _JRPrivate_EnumFromString(NSArray *constants, NSString *enumLabel, NSInteger *enumValue) {
-    NSNumber *value = [_JRPrivate_EnumByLabel(constants) objectForKey:enumLabel];
+static BOOL _JRPrivate_EnumFromString(NSArray *labelsAndValues, NSString *enumLabel, NSInteger *enumValue) {
+    NSNumber *value = [_JRPrivate_EnumByLabel(labelsAndValues) objectForKey:enumLabel];
     if (value) {
         *enumValue = [value integerValue];
         return YES;
@@ -83,30 +83,30 @@ typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
 };    \
 \
 \
-static NSArray* _##ENUM_TYPENAME##KeysAndValues() {	\
-    NSString *constantsString = @"" #ENUM_CONSTANTS; \
-    return _JRPrivate_ParseEnumFromString(constantsString); \
+static NSArray* _##ENUM_TYPENAME##LabelsAndValues() {	\
+    NSString *enumString = @"" #ENUM_CONSTANTS; \
+    return _JRPrivate_ParseEnumLabelsAndValuesFromString(enumString); \
 } \
 \
 static NSDictionary* ENUM_TYPENAME##ByValue() {	\
-    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
-    return _JRPrivate_EnumByValue(constants); \
+    NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
+    return _JRPrivate_EnumByValue(labelsAndValues); \
 }	\
 \
 static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
-    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
-    return _JRPrivate_EnumByLabel(constants); \
+    NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
+    return _JRPrivate_EnumByLabel(labelsAndValues); \
 }	\
 \
 static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
-    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
+    NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
     NSString *enumTypeName = @"" #ENUM_TYPENAME; \
-    return _JRPrivate_EnumToString(constants, enumTypeName, enumValue); \
+    return _JRPrivate_EnumToString(labelsAndValues, enumTypeName, enumValue); \
 }	\
 \
 static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
-    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
-    return _JRPrivate_EnumFromString(constants, enumLabel, enumValue); \
+    NSArray *labelsAndValues = _##ENUM_TYPENAME##LabelsAndValues();	\
+    return _JRPrivate_EnumFromString(labelsAndValues, enumLabel, enumValue); \
 }
 
 //--

--- a/JREnum.h
+++ b/JREnum.h
@@ -4,84 +4,109 @@
 //   Some rights reserved: http://opensource.org/licenses/mit
 //   https://github.com/rentzsch/JREnum
 
+static NSArray* _JRPrivate_ParseEnumFromString(NSString *rawString) {
+    NSString *enumString = [[rawString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""];
+    if ([enumString hasSuffix:@","]) {
+        enumString = [enumString substringToIndex:[enumString length]-1];
+    }
+    NSArray *stringPairs = [enumString componentsSeparatedByString:@","];
+    NSMutableArray *labelsAndValues = [NSMutableArray arrayWithCapacity:[stringPairs count]];
+    int nextDefaultValue = 0;
+    for (NSString *stringPair in stringPairs) {
+        NSArray *labelAndValueString = [stringPair componentsSeparatedByString:@"="];
+        NSString *label = [labelAndValueString objectAtIndex:0];
+        NSString *valueString = [labelAndValueString count] > 1 ? [labelAndValueString objectAtIndex:1] : nil;
+        int value;
+        if (valueString) {
+            NSRange shiftTokenRange = [valueString rangeOfString:@"<<"];
+            if (shiftTokenRange.location != NSNotFound) {
+                valueString = [valueString substringFromIndex:shiftTokenRange.location + 2];
+                value = 1 << [valueString intValue];
+            } else if ([valueString hasPrefix:@"0x"]) {
+                [[NSScanner scannerWithString:valueString] scanHexInt:(unsigned int*)&value];
+            } else {
+                value = [valueString intValue];
+            }
+        } else {
+            value = nextDefaultValue;
+        }
+        nextDefaultValue = value + 1;
+        [labelsAndValues addObject:label];
+        [labelsAndValues addObject:[NSNumber numberWithInt:value]];
+    }
+    return labelsAndValues;
+}
+
+static NSDictionary* _JRPrivate_EnumByValue(NSArray *constants) {
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];
+    for (NSUInteger i = 0; i < [constants count]; i += 2) {
+        NSString *label = [constants objectAtIndex:i];
+        NSNumber *value = [constants objectAtIndex:i+1];
+        [result setObject:label forKey:value];
+    }
+    return result;
+}
+
+static NSDictionary* _JRPrivate_EnumByLabel(NSArray *constants) {
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];
+    for (NSUInteger i = 0; i < [constants count]; i += 2) {
+        NSString *label = [constants objectAtIndex:i];
+        NSNumber *value = [constants objectAtIndex:i+1];
+        [result setObject:value forKey:label];
+    }
+    return result;
+}
+
+static NSString* _JRPrivate_EnumToString(NSArray *constants, NSString *enumTypeName, int enumValue) {
+    NSString *result = [_JRPrivate_EnumByValue(constants) objectForKey:[NSNumber numberWithInt:enumValue]];
+    if (!result) {
+        result = [NSString stringWithFormat:@"<unknown %@: %d>", enumTypeName, enumValue];
+    }
+    return result;
+}
+
+static BOOL _JRPrivate_EnumFromString(NSArray *constants, NSString *enumLabel, NSInteger *enumValue) {
+    NSNumber *value = [_JRPrivate_EnumByLabel(constants) objectForKey:enumLabel];
+    if (value) {
+        *enumValue = [value integerValue];
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
+
+
 #define JREnum(ENUM_TYPENAME, ENUM_CONSTANTS...)    \
 typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
     ENUM_CONSTANTS  \
 };    \
 \
 \
-static NSArray* _JREnumParse##ENUM_TYPENAME##ConstantsString() {	\
+static NSArray* _##ENUM_TYPENAME##KeysAndValues() {	\
     NSString *constantsString = @"" #ENUM_CONSTANTS; \
-    constantsString = [[constantsString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] componentsJoinedByString:@""]; \
-    if ([constantsString hasSuffix:@","]) { \
-        constantsString = [constantsString substringToIndex:[constantsString length]-1]; \
-    } \
-    NSArray *stringPairs = [constantsString componentsSeparatedByString:@","];	\
-    NSMutableArray *labelsAndValues = [NSMutableArray arrayWithCapacity:[stringPairs count]];	\
-    int nextDefaultValue = 0;	\
-    for (NSString *stringPair in stringPairs) {	\
-        NSArray *labelAndValueString = [stringPair componentsSeparatedByString:@"="];	\
-        NSString *label = [labelAndValueString objectAtIndex:0];	\
-        NSString *valueString = [labelAndValueString count] > 1 ? [labelAndValueString objectAtIndex:1] : nil;	\
-        int value; \
-        if (valueString) { \
-            NSRange shiftTokenRange = [valueString rangeOfString:@"<<"]; \
-            if (shiftTokenRange.location != NSNotFound) { \
-                valueString = [valueString substringFromIndex:shiftTokenRange.location + 2]; \
-                value = 1 << [valueString intValue]; \
-            } else if ([valueString hasPrefix:@"0x"]) { \
-                [[NSScanner scannerWithString:valueString] scanHexInt:(unsigned int*)&value]; \
-            } else { \
-                value = [valueString intValue]; \
-            } \
-        } else { \
-            value = nextDefaultValue; \
-        } \
-        nextDefaultValue = value + 1;	\
-        [labelsAndValues addObject:label];	\
-        [labelsAndValues addObject:[NSNumber numberWithInt:value]];	\
-    }	\
-    return labelsAndValues;	\
-}	\
+    return _JRPrivate_ParseEnumFromString(constantsString); \
+} \
 \
 static NSDictionary* ENUM_TYPENAME##ByValue() {	\
-    NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
-    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
-    for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
-        NSString *label = [constants objectAtIndex:i];	\
-        NSNumber *value = [constants objectAtIndex:i+1];	\
-        [result setObject:label forKey:value];	\
-    }	\
-    return result;	\
+    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
+    return _JRPrivate_EnumByValue(constants); \
 }	\
 \
 static NSDictionary* ENUM_TYPENAME##ByLabel() {	\
-    NSArray *constants = _JREnumParse##ENUM_TYPENAME##ConstantsString();	\
-    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[constants count] / 2];	\
-    for (NSUInteger i = 0; i < [constants count]; i += 2) {	\
-        NSString *label = [constants objectAtIndex:i];	\
-        NSNumber *value = [constants objectAtIndex:i+1];	\
-        [result setObject:value forKey:label];	\
-    }	\
-    return result;	\
+    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
+    return _JRPrivate_EnumByLabel(constants); \
 }	\
 \
 static NSString* ENUM_TYPENAME##ToString(int enumValue) {	\
-    NSString *result = [ENUM_TYPENAME##ByValue() objectForKey:[NSNumber numberWithInt:enumValue]];	\
-    if (!result) {	\
-        result = [NSString stringWithFormat:@"<unknown "#ENUM_TYPENAME": %d>", enumValue];	\
-    }	\
-    return result;	\
+    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
+    NSString *enumTypeName = @"" #ENUM_TYPENAME; \
+    return _JRPrivate_EnumToString(constants, enumTypeName, enumValue); \
 }	\
 \
 static BOOL ENUM_TYPENAME##FromString(NSString *enumLabel, ENUM_TYPENAME *enumValue) {	\
-    NSNumber *value = [ENUM_TYPENAME##ByLabel() objectForKey:enumLabel];	\
-    if (value) {	\
-        *enumValue = (ENUM_TYPENAME)[value intValue];	\
-        return YES;	\
-    } else {	\
-    return NO;	\
-    }	\
+    NSArray *constants = _##ENUM_TYPENAME##KeysAndValues();	\
+    return _JRPrivate_EnumFromString(constants, enumLabel, enumValue); \
 }
 
 //--

--- a/JREnum.h
+++ b/JREnum.h
@@ -5,9 +5,9 @@
 //   https://github.com/rentzsch/JREnum
 
 #define JREnum(ENUM_TYPENAME, ENUM_CONSTANTS...)    \
-    typedef enum {  \
+    typedef NS_ENUM(NSInteger, ENUM_TYPENAME) {  \
         ENUM_CONSTANTS  \
-    } ENUM_TYPENAME;    \
+    };    \
     static NSString *_##ENUM_TYPENAME##_constants_string = @"" #ENUM_CONSTANTS; \
     _JREnum_GenerateImplementation(ENUM_TYPENAME)
 

--- a/JREnum.h
+++ b/JREnum.h
@@ -95,9 +95,10 @@ static NSDictionary* _JRPrivate_EnumByLabel(NSArray *labelsAndValues) {
  @return The label for enumValue.
  */
 static NSString* _JRPrivate_EnumToString(NSArray *labelsAndValues, NSString *enumTypeName, NSInteger enumValue) {
-    NSString *result = [_JRPrivate_EnumByValue(labelsAndValues) objectForKey:[NSNumber numberWithInt:enumValue]];
+    NSNumber *number = [NSNumber numberWithInteger:enumValue];
+    NSString *result = [_JRPrivate_EnumByValue(labelsAndValues) objectForKey:number];
     if (!result) {
-        result = [NSString stringWithFormat:@"<unknown %@: %d>", enumTypeName, enumValue];
+        result = [NSString stringWithFormat:@"<unknown %@: %@>", enumTypeName, number];
     }
     return result;
 }

--- a/JREnumTest/JREnumTest.xcodeproj/project.pbxproj
+++ b/JREnumTest/JREnumTest.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		795439BE16756A7C00B88D38 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 795439BD16756A7C00B88D38 /* Foundation.framework */; };
 		795439C116756A7C00B88D38 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 795439C016756A7C00B88D38 /* main.m */; };
 		795439CE16756AE000B88D38 /* SplitEnums.m in Sources */ = {isa = PBXBuildFile; fileRef = 795439CD16756AE000B88D38 /* SplitEnums.m */; };
+		827D16A11AA4701800B6E02B /* DummyClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 827D16A01AA4701800B6E02B /* DummyClass.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,6 +33,8 @@
 		795439CB16756A9200B88D38 /* JREnum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JREnum.h; path = ../../JREnum.h; sourceTree = "<group>"; };
 		795439CC16756AE000B88D38 /* SplitEnums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplitEnums.h; sourceTree = "<group>"; };
 		795439CD16756AE000B88D38 /* SplitEnums.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SplitEnums.m; sourceTree = "<group>"; };
+		827D169F1AA4701800B6E02B /* DummyClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DummyClass.h; sourceTree = "<group>"; };
+		827D16A01AA4701800B6E02B /* DummyClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DummyClass.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +80,8 @@
 				795439C016756A7C00B88D38 /* main.m */,
 				795439CC16756AE000B88D38 /* SplitEnums.h */,
 				795439CD16756AE000B88D38 /* SplitEnums.m */,
+				827D169F1AA4701800B6E02B /* DummyClass.h */,
+				827D16A01AA4701800B6E02B /* DummyClass.m */,
 				795439CB16756A9200B88D38 /* JREnum.h */,
 				795439C216756A7C00B88D38 /* Supporting Files */,
 			);
@@ -142,6 +147,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				827D16A11AA4701800B6E02B /* DummyClass.m in Sources */,
 				795439C116756A7C00B88D38 /* main.m in Sources */,
 				795439CE16756AE000B88D38 /* SplitEnums.m in Sources */,
 			);

--- a/JREnumTest/JREnumTest/DummyClass.h
+++ b/JREnumTest/JREnumTest/DummyClass.h
@@ -1,0 +1,22 @@
+//
+//  DummyClass.h
+//  JREnumTest
+//
+//  Created by Benedict Cohen on 02/03/2015.
+//  Copyright (c) 2015 Jonathan 'Wolf' Rentzsch. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+/*
+ This file exists so that SplitEnums.h is #import-ed into more than one file so that duplicate symbol problems can be found in JREnum implementation.
+ */
+
+#import "SplitEnums.h"
+
+
+
+@interface DummyClass : NSObject
+
+@end

--- a/JREnumTest/JREnumTest/DummyClass.m
+++ b/JREnumTest/JREnumTest/DummyClass.m
@@ -1,0 +1,15 @@
+//
+//  DummyClass.m
+//  JREnumTest
+//
+//  Created by Benedict Cohen on 02/03/2015.
+//  Copyright (c) 2015 Jonathan 'Wolf' Rentzsch. All rights reserved.
+//
+
+#import "DummyClass.h"
+
+
+
+@implementation DummyClass
+
+@end


### PR DESCRIPTION
By marking the functions as static we can do away with JREnumDefine/Declare and just use JREnum. 

Is there a reason why the macros weren't initially implemented like this? I feel like I must be overlooking something as this seems to obvious to miss. The only downside I can think of is a slight increase in binary size as the functions will be included for each translation unit. Are there any others?
